### PR TITLE
Allow to set state from outside to continue playing after autoplay

### DIFF
--- a/index.js
+++ b/index.js
@@ -477,6 +477,9 @@ window.exports = {};
             autoplayMoves = moves;
             autoplay();
         },
+        setState: function (state) {
+            setState(state);
+        },
     };
 
     function generateScene() {


### PR DESCRIPTION
So can use window.exports.setState(1) after autoplay to continue.